### PR TITLE
Excluding tests from installation for dmiparser package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,8 @@ packages = find:
 setup_requires = pytest-runner
 tests_require = pytest
 zip_safe = True
+
+[options.packages.find]
 exclude = 
     tests*
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,8 @@ packages = find:
 setup_requires = pytest-runner
 tests_require = pytest
 zip_safe = True
+exclude = 
+    tests*
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This PR addresses the issue with additional installation of tests during dmiparser package installation.